### PR TITLE
Added UT2003 (Demo) working with openspy as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The scripts support retrieval for following games from the listed sources. If yo
 | Tremulous                              | Quake3               | tremulous.net                                                                                                     |
 | Unreal                                 | GameSpy              | 333networks.com, errorist.eu, openspy.net, oldunreal.com, qtracker.com                                            |
 | Unreal Tournament                      | GameSpy              | 333networks.com, errorist.eu, openspy.net, oldunreal.com, qtracker.com                                            |
+| Unreal Tournament 2003 (Demo)                | Unreal2              | openspy.net                                                                                                       |
 | Unreal Tournament 2003                 | Unreal2              | openspy.net                                                                                                       |
 | Unreal Tournament 2004                 | Unreal2              | openspy.net, 333networks.com, errorist.eu                                                                         |
 | Unreal Tournament 3                    | GameSpy              | openspy.net                                                                                                       |


### PR DESCRIPTION
The demo was released on Linux/Windows in 2002, updated several times and a lively community kept playing the demo only for years. [More info and win32 binary here](https://github.com/SicariusFeroxis/ut2003demo/releases/tag/ut2003demo_v2206)